### PR TITLE
[FIX] compile handout (MikTex)

### DIFF
--- a/Handout/handout.tex
+++ b/Handout/handout.tex
@@ -9,17 +9,14 @@
 \hyphenation{OpenMS}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-% FONT SELECTION -> WE NOW USE UBUNTU FONT AND XETEX FOR A MORE PROFESSIONAL
-% LOOK.
-% UBUNTU FONT CAN BE DOWNLOADED FROM HERE: http://font.ubuntu.com
-% THEY SHOULD ALSO BE INCLUDED IN THE REPOSITORY.
-% WE TRIED TO USE RELATIVE PATHS BUT IT DOES NOT SEEM TO ALWAYS WORK
-% WITH THE FONTSPEC PACKAGE. THEREFORE PLEASE INSTALL THE FONTS WITH THE
-% METHODS FOR YOUR OS BEFORE COMPILING.
-%
+% We use UBUNTU font for a more professional look.
+% UBUNTU fonts can be downloaded from: http://font.ubuntu.com.
+% but are also included in this repository at ./fonts.
+% 
 \usepackage{fontspec}
 
-
+% If (for some reason), this command does not work, manually install the fonts system-wide and use
+% \setmainfont {Ubuntu}
 \setmainfont[
   Ligatures=TeX,
   Path=./fonts/,
@@ -35,6 +32,8 @@
   FontFace={k}{it}{*-BI}
 ] {Ubuntu}
 
+% If (for some reason), this command does not work, manually install the fonts system-wide and use
+% \setmainfont {UbuntuMono}
 \setmonofont[
   Ligatures=TeX,
   Path=./fonts/,

--- a/Handout/handout.tex
+++ b/Handout/handout.tex
@@ -19,31 +19,31 @@
 %
 \usepackage{fontspec}
 
-\setmainfont{Ubuntu}
-%[
-%  Ligatures=TeX,
-%  Path=fonts/,
-%  Extension=.ttf,
-%  UprightFont=*-R,
-%  ItalicFont=*-I,
-%  BoldFont=*-B,
-%  BoldItalicFont=*-BI,
-%  FontFace={l}{n}{*-L},
-%  FontFace={l}{it}{*-LI},
-%  FontFace={mb}{n}{*-M},
-%  FontFace={mb}{it}{*-MI},
-%  FontFace={k}{n}{*-B},
-%  FontFace={k}{it}{*-BI}
-%]
-\setmonofont{Ubuntu Mono}
-%[
-%  Ligatures=TeX,
-%  Path=fonts/,
-%  Extension=.ttf,
-%  UprightFont=*-R,
-%  BoldFont=*-B,
-%  BoldItalicFont=*-BI
-%]
+
+\setmainfont[
+  Ligatures=TeX,
+  Path=./fonts/,
+  Extension=.ttf,
+  UprightFont=*-R,
+  BoldFont=*-B,
+  BoldItalicFont=*-BI,
+  FontFace={l}{n}{*-L},
+  FontFace={l}{it}{*-LI},
+  FontFace={mb}{n}{*-M},
+  FontFace={mb}{it}{*-MI},
+  FontFace={k}{n}{*-B},
+  FontFace={k}{it}{*-BI}
+] {Ubuntu}
+
+\setmonofont[
+  Ligatures=TeX,
+  Path=./fonts/,
+  Extension=.ttf,
+  UprightFont=*-R,
+  BoldFont=*-B,
+  BoldItalicFont=*-BI
+] {UbuntuMono}
+
 % math fonts
 %\usepackage[math-style=TeX]{unicode-math}
 %\setmathfont{Cambria Math}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Tutorials
 Handouts and workflows as used in the tutorial session during user meetings. 
 
+Build handout:
+- compile PDF from `./Handouts/handout.tex` using XeLatex
+
+
 Note:
 - Please put only the handouts and workflows (small files) here. Installers, external tools, and example data should be kept in the releases.
-- Please assign a git tag for any special  tutorial event with a separate release
+- Please assign a Git tag for any special tutorial event with a separate release


### PR DESCRIPTION
on Windows, the Ubuntu fonts must be searched in the subdir ./fonts/ (since they are not installed by default -- and that would require admin rights!).

Also, according to http://tex.stackexchange.com/questions/12565/load-fonts-that-are-in-a-fonts-directory
the fontnames must be identically named to the ttf file (incl. spaces), i.e. "UbuntuMono", not "Ubuntu Mono".

With the fixes here, a default MikTex XeLatex will complile the PDF on Windows.