### PR TITLE
PCA replace ggbiplot to ggfortify -> update import

### DIFF
--- a/Handout/metabolomics.tex
+++ b/Handout/metabolomics.tex
@@ -394,7 +394,7 @@ Inspect the nodes of this section. Customize your visualization and possibly try
 
 \subsubsection{Advanced visualization}
 \label{sec:metaboR}
-R Dependencies: This section requires that the R packages ggplot2 and ggbiplot are both installed. ggplot2 is part of the \textit{KNIME R Statistics Integration (Windows Binaries)} which should already be installed via the full KNIME installer, ggbiplot however is not.
+R Dependencies: This section requires that the R packages ggplot2 and ggfortify are both installed. ggplot2 is part of the \textit{KNIME R Statistics Integration (Windows Binaries)} which should already be installed via the full KNIME installer, ggfortify however is not.
 In case that you use an R installation where one or both of them are not yet installed, add an \KNIMENODE{R Snippet} node and double-click to configure. In the \textit{R Script} text editor, enter the following code:
 \begin{lstlisting}
 #Include the next line if you also have to install ggplot2:


### PR DESCRIPTION
The most current(?) PCA Snippet switched to ggfortify instead of ggbiplot (which required devtools). Consequently, the text should list ggfortify as dependency instead.