### PR TITLE
very long nightly path needs more space -> deitemize

### DIFF
--- a/Handout/gettingstarted.tex
+++ b/Handout/gettingstarted.tex
@@ -290,7 +290,10 @@ Instructions for the unstable, nightly release:
  % If you base the tutorial on the nightly contributions (not recommended - more of a emergency measure)
   \item \label{it:add_site} In the now open dialog choose \menu{Add...} (in the upper right corner of the dialog) to define a new update site. In the opening dialog enter the following details. \\
   \textit{Name:} \texttt{Trunk Community Contributions} \\
-  \textit{Location:} \menu{\KnimeTrunkSite}
+  \textit{Location:} 
+\end{itemize}  
+  \menu{\KnimeTrunkSite}
+\begin{itemize}
   \item \label{it:select_site} After pressing \keys{OK} KNIME will show you all the contents of the added Update Site.
   \item \textbf{Note:} From now on, you can use this repository for plugins in the \menu{Work with:} drop-down list.
   \item Select the \textbf{OpenMS} nodes in the category: \\ "KNIME Community Contributions - Bioinformatics \& NGS" and click \keys{Next}.


### PR DESCRIPTION
the abibuilder msstats feature path for KNIME needs so much space that the current solution doesn't show the full string.

As one possible solution, I removed it from the surrounding itemize so that it starts further to the left than the surrounding text check list